### PR TITLE
lazily import `node-fetch`

### DIFF
--- a/src/_utils/getCarbonDataForWebsite.js
+++ b/src/_utils/getCarbonDataForWebsite.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-const fetch = require("node-fetch").default;
-
 /**
  *
  * @param {string} url
@@ -23,5 +21,6 @@ const fetch = require("node-fetch").default;
  * @see https://api.websitecarbon.com/
  */
 module.exports = async function getCarbonDataForWebsite(url) {
+  const fetch = (await import("node-fetch")).default;
   return (await fetch(`https://api.websitecarbon.com/site?url=${url}`)).json();
 };


### PR DESCRIPTION
`node-fetch` can't be imported into a ESM module with `require`